### PR TITLE
Query wp-calypso for latest commit to record as artifact

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ checkout:
   post:
     - git submodule init
     - git submodule update --remote --force
+    - touch $CIRCLE_ARTIFACTS/$(curl https://api.github.com/repos/Automattic/wp-calypso/commits 2>/dev/null | jq -r '.[0].sha')
 
 dependencies:
   cache_directories:


### PR DESCRIPTION
Adds the commit hash for the latest change to wp-calypso/master as a build artifact so it can be referenced later