### PR TITLE
Add support for E2E_BRANCH parameter, removed parallel CI flag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,5 +20,4 @@ dependencies:
 
 test:
   override:
-    - cd wp-e2e-tests && ./run.sh -R -C $RUN_ARGS:
-        parallel: true
+    - cd wp-e2e-tests && git checkout origin/${E2E_BRANCH-master} && ./run.sh -R -C $RUN_ARGS


### PR DESCRIPTION
This pairs with https://github.com/Automattic/wp-e2e-tests/pull/531 to use Magellan to provide the parallel test runs on a single container rather than using multiple CircleCI containers.  Magellan also provides a single retry of a failed test.