### PR TITLE
Update circle config to use npm ci and cache the npm cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,12 @@ jobs:
       - run: cd wp-e2e-tests && git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
           keys: 
-             - v1-node10-{{ checksum "wp-e2e-tests/package-lock.json" }}
-             - v1-node10
-             
+             - v1-{{ checksum "wp-e2e-tests/.nvmrc" }}-{{ checksum "wp-e2e-tests/package-lock.json" }}
+             - v1-{{ checksum "wp-e2e-tests/.nvmrc" }}
+
       - run: cd wp-e2e-tests && npm ci
       - save_cache:
-          key: v1-node10-{{ checksum "wp-e2e-tests/package-lock.json" }}
+          key: v1-{{ checksum "wp-e2e-tests/.nvmrc" }}-{{ checksum "wp-e2e-tests/package-lock.json" }}
           paths:
             - ~/.npm
       - run: sudo chmod +x wp-e2e-tests/node_modules/.bin/magellan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,15 @@ jobs:
       - run: git submodule update --remote --force
       - run: cd wp-e2e-tests && git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
-          key: v1-{{ checksum "wp-e2e-tests/package-lock.json" }}
-      - run: cd wp-e2e-tests && npm install
+          keys: 
+             - v1-node10-{{ checksum "wp-e2e-tests/package-lock.json" }}
+             - v1-node10
+             
+      - run: cd wp-e2e-tests && npm ci
       - save_cache:
-          key: v1-{{ checksum "wp-e2e-tests/package-lock.json" }}
+          key: v1-node10-{{ checksum "wp-e2e-tests/package-lock.json" }}
           paths:
-            - "wp-e2e-tests/node_modules"
+            - ~/.npm
       - run: sudo chmod +x wp-e2e-tests/node_modules/.bin/magellan
       - run: cd wp-e2e-tests && npm run decryptconfig && ./run.sh -R -C $RUN_ARGS
       - store_test_results:


### PR DESCRIPTION
This changes how node_modules are installed and what's cached.

`npm ci` offers a faster, stricter, more reliable install. If all modules are available in the npm cache (at `~/.npm`, no network traffic is necessary.

This also adds a heirarchical cache so even if we don't have a cache from the full lockfile, we still have some modules cached from the first build on node 10. 

I wrote this up because i noticed the current build is never using the cache. This is because `npm install` is rewriting the lockfile on every run, which changes the cache key.