### PR TITLE
Use a specific sha to run tests so that it matches what we're testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - run: git submodule init
       - run: git submodule update --remote --force
-      - run: cd wp-calypso && git checkout origin/${E2E_BRANCH-master}
+      - run: cd wp-calypso && git checkout ${stage_revision-origin/master}
       - restore_cache:
           keys:
              - v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}


### PR DESCRIPTION
This repo runs the canaries against staging environment. Now that the tests are in the same repo as the changes, we want to run the same version of the test that staging is using. This checks out the correct commit if we have it, or runs against the latest on master if we don't.

No sha (uses master):
https://circleci.com/gh/Automattic/wp-e2e-tests-canary/11950

With sha
https://circleci.com/gh/Automattic/wp-e2e-tests-canary/11951