### PR TITLE
Update to read chromedriver version from file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
              - v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}
              - v1-{{ checksum "wp-calypso/.nvmrc" }}
       - run: |
-        cd wp-calypso/test/e2e &&
-        CHROMEDRIVER_VERSION=$(<.chromedriver_version) npm ci
+          cd wp-calypso/test/e2e &&
+          CHROMEDRIVER_VERSION=$(<.chromedriver_version) npm ci
       - save_cache:
           key: v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
           keys:
              - v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}
              - v1-{{ checksum "wp-calypso/.nvmrc" }}
-      - run: cd wp-calypso/test/e2e && npm ci
+      - run: |
+        cd wp-calypso/test/e2e &&
+        CHROMEDRIVER_VERSION=$(<.chromedriver_version) npm ci
       - save_cache:
           key: v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}
           paths:


### PR DESCRIPTION
Relate to Automattic/wp-calypso#34238

This will have the config read the chromedriver version from a file so that it stays in sync with wp-calypso