### PR TITLE
Run canaries in Sauce

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           paths:
             - ~/.npm
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
-      - run: cd wp-calypso/test/e2e && npm run decryptconfig && ./run.sh -R -C $RUN_ARGS
+      - run: cd wp-calypso/test/e2e && npm run decryptconfig && ./run.sh -R -C -l osx-chrome $RUN_ARGS
       - store_test_results:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           paths:
             - ~/.npm
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
-      - run: cd wp-calypso/test/e2e && npm run decryptconfig && ./run.sh -R -C -l osx-chrome $RUN_ARGS
+      - run: cd wp-calypso/test/e2e && npm run decryptconfig && ./run.sh -R -C $SAUCE_ARG $RUN_ARGS
       - store_test_results:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:


### PR DESCRIPTION
This PR adds a param to run the canaries in Sauce labs. This should keep them running even when we've hit rate limit on full suite

This will pass when https://github.com/Automattic/wp-calypso/pull/37420 is merged in. It has a few tweaks that make them pass in CircleCI. 