### PR TITLE
Build calypso with yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,17 +14,19 @@ jobs:
       - run: cd wp-calypso && git checkout ${stage_revision-origin/master}
       - restore_cache:
           keys:
-             - v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}
-             - v1-{{ checksum "wp-calypso/.nvmrc" }}
+            - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
+            - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}
+            - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}
+            - v1-packages
       - run: |
           cd wp-calypso/test/e2e &&
-          CHROMEDRIVER_VERSION=$(<.chromedriver_version) npm ci
+          CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn --frozen-lockfile
       - save_cache:
-          key: v1-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package-lock.json" }}
+          key: v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
           paths:
-            - ~/.npm
+            - ~/.cache/yarn
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
-      - run: cd wp-calypso/test/e2e && npm run decryptconfig && ./run.sh -R -C $SAUCE_ARG $RUN_ARGS
+      - run: cd wp-calypso/test/e2e && yarn run decryptconfig && ./run.sh -R -C $SAUCE_ARG $RUN_ARGS
       - store_test_results:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:


### PR DESCRIPTION
Changes the CI settings to be compatible with Automattic/wp-calypso#41398

* Use `yarn` instead of `npm` to build e2e tests
* Use `yarn.lock` instead of `package-lock.json` to build package caches
