### PR TITLE
Load chromedriver from the system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
         environment:
           NODE_ENV: test
           TARGET: CANARY
+          DETECT_CHROMEDRIVER_VERSION: 'false'
+          CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
     steps:
       - checkout
       - run: git submodule init
@@ -19,12 +21,14 @@ jobs:
             - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}
             - v1-packages
       - run: |
-          cd wp-calypso/test/e2e &&
-          CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn --frozen-lockfile
+          cd wp-calypso/test/e2e && yarn --frozen-lockfile
       - save_cache:
           key: v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
           paths:
             - ~/.cache/yarn
+      - run: |
+          google-chrome --version > wp-calypso/test/e2e/.chromedriver_version
+          echo -n "Google Chrome version: " && cat wp-calypso/test/e2e/.chromedriver_version
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: cd wp-calypso/test/e2e && yarn run decryptconfig && ./run.sh -R -C $SAUCE_ARG $RUN_ARGS
       - store_test_results:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses `chromedriver` binary present on the system instead of downloading it again. Because both `chromedriver` and Chrome come from the base circleci image this should guarantee we always use compatible versions.

Related PRs:
* https://github.com/Automattic/wp-calypso/pull/43318
* https://github.com/Automattic/wp-e2e-tests-for-branches/pull/58