### PR TITLE
Use the right path for yarn cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,15 @@ jobs:
       - run: cd wp-calypso && git checkout ${stage_revision-origin/trunk}
       - restore_cache:
           keys:
-            - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
-            - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}
-            - v1-packages-{{ checksum "wp-calypso/.nvmrc" }}
-            - v1-packages
+            - v2-packages-{{ checksum "wp-calypso/.yarnrc.yml" }}
+            - v2-packages
       - run: |
-          cd wp-calypso/test/e2e && yarn --frozen-lockfile
+          cd wp-calypso/test/e2e && yarn --immutable
       - save_cache:
-          key: v1-packages-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/yarn.lock" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
+          key: v2-packages-{{ checksum "wp-calypso/.yarnrc.yml" }}
           paths:
-            - ~/.cache/yarn
+            # This is the default path when using enableGlobalCache:true
+            - ~/.yarn/berry/cache
       - run: |
           google-chrome --version > wp-calypso/test/e2e/.chromedriver_version
           echo -n "Google Chrome version: " && cat wp-calypso/test/e2e/.chromedriver_version


### PR DESCRIPTION
Fixes yarn cache:

- Use the right path for yarn 3.x (`~/.yarn/berry/cache`). Value obtained by running `yarn config | grep cache`
- Only use `yarnrc.yml` as the cache key. The cache is just a bunch of packages stores as `.tgz` downloaded form the registry. If a package+version is in the cache it will be used, if not it will be downloaded again. It doesn't depend on Node version, and it wouldn't make sense to invalidate the whole cache if `package.json` changes. The reason for using `yarnrc.yml` as the key is in case we change the cache location.

Similar PR in Calypso: https://github.com/Automattic/wp-calypso/pull/57597

 